### PR TITLE
Sett eksplisitt tillatelser til GitHub Actions-workeren, av sikkerhet…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v6'
 
       - name: 'Prepare version labels'
         uses: 'k15g/action-version-labels@v1'
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v6'
 
       - name: 'Setup Ruby'
         uses: 'ruby/setup-ruby@v1'
@@ -96,21 +96,21 @@ jobs:
         run: 'make package'
 
       - name: 'Upload bundle.tar.gz (artifact)'
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           path: 'target/*.tar.gz'
           name: 'eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-tar.gz'
           retention-days: 3
 
       - name: 'Upload bundle.zip (artifact)'
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           path: 'target/*.zip'
           name: 'eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-zip'
           retention-days: 3
 
       - name: 'Upload bundle.asice (artifact)'
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v7'
         with:
           path: 'target/*.asice'
           name: 'eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-asice'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,134 +1,144 @@
-name: Build
+name: 'Build'
 
 on:
   push:
     branches:
-      - main
+      - 'main'
   release:
     types:
-      - published
+      - 'published'
   workflow_dispatch:
+
+permissions:
+  contents: 'read'
 
 jobs:
   versions:
-    name: Extract versions
-    runs-on: ubuntu-latest
+    name: 'Extract versions'
+    runs-on: 'ubuntu-latest'
 
+    permissions:
+      contents: 'read'
+    
     outputs:
-      matrix: ${{ env.MATRIX }}
-      version: ${{ env.PROJECT_VERSION }}
+      matrix: '${{ env.MATRIX }}'
+      version: '${{ env.PROJECT_VERSION }}'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: 'Checkout'
+        uses: 'actions/checkout@v3'
 
-      - name: Prepare version labels
-        uses: k15g/action-version-labels@v1
+      - name: 'Prepare version labels'
+        uses: 'k15g/action-version-labels@v1'
         with:
-          prefix: project
+          prefix: 'project'
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+      - name: 'Setup Ruby'
+        uses: 'ruby/setup-ruby@v1'
         with:
           ruby-version: '3.4.2'
 
-      - name: Fetch Ruby dependencies
-        run: make .bundle/vendor
+      - name: 'Fetch Ruby dependencies'
+        run: 'make .bundle/vendor'
 
-      - name: Fetch versions
+      - name: 'Fetch versions'
         run: |
           make versions
           make versions >> $GITHUB_ENV
 
 
   build_bundle:
-    name: Build SDK bundle
-    runs-on: ubuntu-latest
-    needs: versions
+    name: 'Build SDK bundle'
+    runs-on: 'ubuntu-latest'
+    
+    permissions:
+      contents: 'write'
+    
+    needs: 'versions'
 
     strategy:
       matrix: 
-        include: ${{fromJSON(needs.versions.outputs.matrix)}}
+        include: '${{fromJSON(needs.versions.outputs.matrix)}}'
 
     env:
-      EFORMS_MINOR: ${{ matrix.EFORMS_MINOR }}
-      EFORMS_PATCH: ${{ matrix.EFORMS_PATCH }}
-      PROJECT_VERSION: ${{needs.versions.outputs.version}}
+      EFORMS_MINOR: '${{ matrix.EFORMS_MINOR }}'
+      EFORMS_PATCH: '${{ matrix.EFORMS_PATCH }}'
+      PROJECT_VERSION: '${{needs.versions.outputs.version}}'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: 'Checkout'
+        uses: 'actions/checkout@v3'
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+      - name: 'Setup Ruby'
+        uses: 'ruby/setup-ruby@v1'
         with:
           ruby-version: '3.4.2'
 
-      - name: Fetch Ruby dependencies
-        run: make .bundle/vendor
+      - name: 'Fetch Ruby dependencies'
+        run: 'make .bundle/vendor'
 
-      - name: Fetch eForms SDK
-        run: make target/eforms-sdk
+      - name: 'Fetch eForms SDK'
+        run: 'make target/eforms-sdk'
 
-      - name: Fetch Saxon
-        run: make target/saxon
+      - name: 'Fetch Saxon'
+        run: 'make target/saxon'
 
-      - name: Status
-        run: make status
+      - name: 'Status'
+        run: 'make status'
 
-      - name: Build folder
-        run: make build
+      - name: 'Build folder'
+        run: 'make build'
 
-      - name: Build validator
-        run: make validator
+      - name: 'Build validator'
+        run: 'make validator'
 
-      - name: Package
-        run: make package
+      - name: 'Package'
+        run: 'make package'
 
-      - name: Upload bundle.tar.gz (artifact)
-        uses: actions/upload-artifact@v4
+      - name: 'Upload bundle.tar.gz (artifact)'
+        uses: 'actions/upload-artifact@v4'
         with:
-          path: target/*.tar.gz
-          name: eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-tar.gz
+          path: 'target/*.tar.gz'
+          name: 'eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-tar.gz'
           retention-days: 3
 
-      - name: Upload bundle.zip (artifact)
-        uses: actions/upload-artifact@v4
+      - name: 'Upload bundle.zip (artifact)'
+        uses: 'actions/upload-artifact@v4'
         with:
-          path: target/*.zip
-          name: eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-zip
+          path: 'target/*.zip'
+          name: 'eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-zip'
           retention-days: 3
 
-      - name: Upload bundle.asice (artifact)
-        uses: actions/upload-artifact@v4
+      - name: 'Upload bundle.asice (artifact)'
+        uses: 'actions/upload-artifact@v4'
         with:
-          path: target/*.asice
-          name: eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-asice
+          path: 'target/*.asice'
+          name: 'eforms-sdk-nor-resources-${{ matrix.EFORMS_MINOR }}-${{ env.PROJECT_VERSION }}-asice'
           retention-days: 3
 
-      - name: Upload publishing.tar.gz
-        uses: k15g/action-github-asset-upload@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: 'Upload publishing.tar.gz'
+        uses: 'k15g/action-github-asset-upload@v1'
+        if: 'startsWith(github.ref, "refs/tags/")'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/eforms-sdk-nor-${{ env.PROJECT_VERSION }}.tar.gz
-          name: eforms-sdk-${{ matrix.EFORMS_MINOR }}-nor-${{ env.PROJECT_VERSION }}.tar.gz
-          label: eForms SDK NOR ${{ env.PROJECT_VERSION }} for ${{ matrix.EFORMS_MINOR }} (tar.gz)
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          file: 'target/eforms-sdk-nor-${{ env.PROJECT_VERSION }}.tar.gz'
+          name: 'eforms-sdk-${{ matrix.EFORMS_MINOR }}-nor-${{ env.PROJECT_VERSION }}.tar.gz'
+          label: 'eForms SDK NOR ${{ env.PROJECT_VERSION }} for ${{ matrix.EFORMS_MINOR }} (tar.gz)'
 
-      - name: Upload publishing.zip
-        uses: k15g/action-github-asset-upload@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: 'Upload publishing.zip'
+        uses: 'k15g/action-github-asset-upload@v1'
+        if: 'startsWith(github.ref, "refs/tags/")'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/eforms-sdk-nor-${{ env.PROJECT_VERSION }}.zip
-          name: eforms-sdk-${{ matrix.EFORMS_MINOR }}-nor-${{ env.PROJECT_VERSION }}.zip
-          label: eForms SDK NOR ${{ env.PROJECT_VERSION }} for ${{ matrix.EFORMS_MINOR }} (zip)
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          file: 'target/eforms-sdk-nor-${{ env.PROJECT_VERSION }}.zip'
+          name: 'eforms-sdk-${{ matrix.EFORMS_MINOR }}-nor-${{ env.PROJECT_VERSION }}.zip'
+          label: 'eForms SDK NOR ${{ env.PROJECT_VERSION }} for ${{ matrix.EFORMS_MINOR }} (zip)'
 
-      - name: Upload validation
-        uses: k15g/action-github-asset-upload@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: 'Upload validation'
+        uses: 'k15g/action-github-asset-upload@v1'
+        if: 'startsWith(github.ref, "refs/tags/")'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/dev.anskaffelser.eforms.sdk-${{ matrix.EFORMS_MINOR }}-nor-${{ env.PROJECT_VERSION }}.asice
-          name: dev.anskaffelser.eforms.sdk-${{ matrix.EFORMS_MINOR }}-nor-${{ env.PROJECT_VERSION }}.asice
-          label: Validaton for eForms SDK NOR ${{ env.PROJECT_VERSION }} for ${{ matrix.EFORMS_MINOR }}
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          file: 'target/dev.anskaffelser.eforms.sdk-${{ matrix.EFORMS_MINOR }}-nor-${{ env.PROJECT_VERSION }}.asice'
+          name: 'dev.anskaffelser.eforms.sdk-${{ matrix.EFORMS_MINOR }}-nor-${{ env.PROJECT_VERSION }}.asice'
+          label: 'Validaton for eForms SDK NOR ${{ env.PROJECT_VERSION }} for ${{ matrix.EFORMS_MINOR }}'


### PR DESCRIPTION
…shensyn. Innkapsler også alle YAML-strenger i fnutter, for konsistens og å unngå mystiske parsefeil i fremtiden.