### PR TITLE
chore: use build image from Github Container Registry (GHCR) and make validator image configurable via VALIDATOR_IMAGE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SAXON_MINOR ?= 2
 
 TESTS ?= src/tests
 
-VALIDATOR_IMAGE ?= anskaffelser/validator:edge
+VALIDATOR_IMAGE ?= ghcr.io/anskaffelser/validator:edge
 
 default: clean-light build
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ SAXON_MINOR ?= 2
 
 TESTS ?= src/tests
 
+VALIDATOR_IMAGE ?= anskaffelser/validator:edge
+
 default: clean-light build
 
 clean-light:
@@ -460,7 +462,7 @@ target/dev.anskaffelser.eforms.sdk-nor.asice: target/buildconfig.xml # $$(find s
 	@docker run --rm -i \
 		-v $$(pwd)/target:/src \
 		-u $$(id -u):$$(id -g) \
-		anskaffelser/validator:edge build \
+		$(VALIDATOR_IMAGE) build \
 		 -x -t -n dev.anskaffelser.eforms.sdk-$(EFORMS_MINOR)-nor -b $(VERSION) -target validator-target /src || true
 	@mv target/validator-target/dev.anskaffelser.eforms.sdk-$(EFORMS_MINOR)-nor-$(VERSION).asice target/
 	@rm -rf target/validator-target


### PR DESCRIPTION
* Use new image from Github Container Registry
* Defaults to ghcr.io/anskaffelser/validator:edge, but can be overridden locally or in GitHub Actions by setting the VALIDATOR_IMAGE environment variable.