### PR TITLE
Positiv paths-filter i build-workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - '.bundle/**'
+      - '.github/workflows/**'
+      - 'bin/**'
+      - 'schema/**'
+      - 'src/**'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'Makefile'
+
   release:
     types:
       - 'published'


### PR DESCRIPTION
Intensjonen er å unngå å trigge builds når vi merger inn, eksempelvis, ny Markdowndokumentasjon.